### PR TITLE
Fix parser messing with input

### DIFF
--- a/src/components/FitchBox.jsx
+++ b/src/components/FitchBox.jsx
@@ -57,7 +57,7 @@ export default function FitchBox() {
 
             } catch (error) {
                 if(error instanceof  RuleError)
-                    newLine.error = error.message
+                    newLine.ruleError = error.message
                 else
                     throw error
             }

--- a/src/components/ProofBox.jsx
+++ b/src/components/ProofBox.jsx
@@ -41,17 +41,17 @@ export default function ProofBox({
     if (isTopLevel) {
         premiseBlock.push(<Button sx={{fontSize: 10}} onClick={() => {
             setPremisesEnd(premisesEnd + 1)
-            addLine(new SentenceLine(new Sentence(), new Justification(Rule.derived["Reit"], {}), layer, true), premises.length > 0 ? premises[premises.length - 1][0] + 1 : 0);
+            addLine(new SentenceLine("", new Justification(Rule.derived["Reit"], {}), layer, true), premises.length > 0 ? premises[premises.length - 1][0] + 1 : 0);
         }}
         >Add Premise</Button>)
     }
 
     function addLineAt(i){
-        return addLine(new SentenceLine(new Sentence(), new Justification(Rule.derived["Reit"], {}), layer, false), i)
+        return addLine(new SentenceLine("", new Justification(Rule.derived["Reit"], {}), layer, false), i)
     }
 
     function startSubproofLineAt(i){
-        return addLine(new SentenceLine(new Sentence(), new Justification(Rule.derived["Assumption"], {}), layer + 1, true), i)
+        return addLine(new SentenceLine("", new Justification(Rule.derived["Assumption"], {}), layer + 1, true), i)
     }
 
     // Collate subproofs
@@ -112,12 +112,12 @@ export default function ProofBox({
                 {lineElements}
                 <Box>
                     <Button sx={{fontSize: 10}} onClick={() => {
-                        addLine(new SentenceLine(new Sentence(), new Justification(Rule.derived["Reit"], {}), layer, false), lastLineNumber + 1);
+                        addLine(new SentenceLine("", new Justification(Rule.derived["Reit"], {}), layer, false), lastLineNumber + 1);
                     }}
                     > Add Line
                     </Button>
                     <Button sx={{fontSize: 10}} onClick={() => {
-                        addLine(new SentenceLine(new Sentence(), new Justification(Rule.derived["Assumption"], {}), layer + 1, true), lastLineNumber + 1);
+                        addLine(new SentenceLine("", new Justification(Rule.derived["Assumption"], {}), layer + 1, true), lastLineNumber + 1);
                     }}
                     > Start Subproof </Button>
                 </Box>

--- a/src/components/ProofLineBox.jsx
+++ b/src/components/ProofLineBox.jsx
@@ -72,26 +72,26 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
     };
 
     function updateSentence(text){
-        let sen;
+        let e = null;
         try {
-            sen = parse(text)
+            parse(text)
         } catch (error) {
             if (error.name === "SyntaxError")
-                sen = {text: text, "error": error.message}
+                e = error.message
             else
                 throw error
         }
-        updateFun(new SentenceLine(sen, sentenceLine.justification, sentenceLine.level, sentenceLine.isAssumption));
+        updateFun(new SentenceLine(text, sentenceLine.justification, sentenceLine.level, sentenceLine.isAssumption, e, sentenceLine.ruleError));
     }
 
     const handleSelectChange = (event) => {
         const newJustification = new Justification(Rule.derived[event.target.value], sentenceLine.justification.lines)
-        updateFun(new SentenceLine(sentenceLine.sentence, newJustification, sentenceLine.level, sentenceLine.isAssumption));
+        updateFun(new SentenceLine(sentenceLine.rawString, newJustification, sentenceLine.level, sentenceLine.isAssumption, sentenceLine.parseError, sentenceLine.ruleError));
     };
 
     const handleLinesChange = (event) => {
         const newJustification = new Justification(sentenceLine.justification.rule, readLinesText(event.target.value))
-        updateFun(new SentenceLine(sentenceLine.sentence, newJustification, sentenceLine.level, sentenceLine.isAssumption));
+        updateFun(new SentenceLine(sentenceLine.rawString, newJustification, sentenceLine.level, sentenceLine.isAssumption, sentenceLine.parseError, sentenceLine.ruleError));
     };
 
 
@@ -123,8 +123,8 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
     // Generate proof indicator
     let proofIndicator = (<></>)
     if(!sentenceLine.isAssumption){
-        if (line.error) {
-            proofIndicator = (<Tooltip title={line.error}>
+        if (line.ruleError) {
+            proofIndicator = (<Tooltip title={line.ruleError}>
                 <ErrorIcon color="error"/>
             </Tooltip>)
         } else if (line.isValid) {
@@ -138,7 +138,7 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
         <Box sx={{width: 1}} onContextMenu={handleContextMenu} style={{ cursor: 'context-menu' }}>
             <Grid sx={{justifyContent: "flex-end", alignItems: "flex-end",}}container>
                 <Grid size="grow">
-                    <SentenceComponent sentence={sentenceLine.sentence} updateSentence={updateSentence} />
+                    <SentenceComponent sentence={sentenceLine.rawString} updateSentence={updateSentence} error={sentenceLine.parseError}/>
                 </Grid>
                 {justForm}
                 <Grid size={1}>{proofIndicator}</Grid>

--- a/src/components/SentenceComponent.jsx
+++ b/src/components/SentenceComponent.jsx
@@ -8,13 +8,13 @@ import Stack from '@mui/material/Stack';
 import * as React from "react";
 
 
-export default function SentenceComponent({sentence, updateSentence}){
+export default function SentenceComponent({sentence, updateSentence, error}){
     const [inFocus, setInFocus] = React.useState(false)
 
     function addCharacter(c){
         function inner(event){
             event.preventDefault()
-            updateSentence(sentence.text+c)
+            updateSentence(sentence+c)
         }
         return inner;
     }
@@ -45,6 +45,6 @@ export default function SentenceComponent({sentence, updateSentence}){
                 {CharButton("\u00AC")}
                 {CharButton("\u2227")}
             </ButtonGroup>):<></>}
-            <FormHelperText error={true}>{sentence.error}</FormHelperText>
+            <FormHelperText error={true}>{error}</FormHelperText>
         </Stack>)
 }

--- a/src/fitch/proofstructure.js
+++ b/src/fitch/proofstructure.js
@@ -1,9 +1,17 @@
+import {parse} from "../fitch/structure.js";
+
 export class SentenceLine {
-    constructor(sentence, justification, level, isAssumption = false) {
-        this.sentence = sentence;
+    constructor(rawString, justification, level, isAssumption = false, parseError=null, ruleError=null) {
+        this.rawString = rawString;
         this.justification = justification
         this.level = level
         this.isAssumption = isAssumption
+        this.parseError = parseError
+        this.ruleError = ruleError
+    }
+
+    get sentence(){
+        return parse(this.rawString)
     }
 
     check(lines, targetLine) {

--- a/src/fitch/structure.js
+++ b/src/fitch/structure.js
@@ -52,7 +52,12 @@ export class UnarySentence extends Sentence {
     }
 
     get text() {
-        return this.op + this.right.text
+        if(this.right instanceof Atom || this.right instanceof PropAtoms || this.right instanceof UnarySentence){
+            return this.op + this.right.text
+        } else {
+            return `${this.op}(${this.right.text})`
+        }
+
     };
 
     substitute(vari, cons) {

--- a/test/parser/roundtrip.test.js
+++ b/test/parser/roundtrip.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import {parse} from "../../src/fitch/structure.js";
+import {ConjunctionIntro} from "../../src/fitch/rules.js";
+const charmap = {
+    '&' : "\u2227",
+    '|' : "\u2228",
+    '>': "\u2192",
+    '<>': "\u2194",
+    '~': "\u00AC"
+}
+describe("simple conjunction introduction", () => {
+    const texts = [
+        "~(A|~A)",
+    ].map((x) => x.split("").map((y) => charmap[y]??y).join(""))
+    for(const text of texts) {
+        it(`Roundtrip &{text}`, () => {
+            expect(parse(text).text).equals(text);
+        });
+    }
+})


### PR DESCRIPTION
The parser output used to be used to morph the input into something that matches our syntax. This might mess with the users ability to type some things, which is bad. Therefore, we now only store the raw text and run the parser only for verification and on proof check.

Closes #1