### PR TITLE
Dynamic line references

### DIFF
--- a/src/components/ProofLineBox.jsx
+++ b/src/components/ProofLineBox.jsx
@@ -97,7 +97,6 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
 
     let justForm = null;
     if (!sentenceLine.isAssumption) {
-        console.log(sentenceLine.justification)
         justForm = [
             (<Grid size={2}>
                 <Select

--- a/src/components/ProofLineBox.jsx
+++ b/src/components/ProofLineBox.jsx
@@ -97,6 +97,7 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
 
     let justForm = null;
     if (!sentenceLine.isAssumption) {
+        console.log(sentenceLine.justification)
         justForm = [
             (<Grid size={2}>
                 <Select
@@ -113,7 +114,7 @@ export default function ProofLineBox({lineNum, line, removeLine, addLineAfter, a
                            size="small"
                            error={sentenceLine.justification.lines.error}
                            helperText={sentenceLine.justification.lines.error ? sentenceLine.justification.lines.error : ""}
-                           value={sentenceLine.justification.lines.text}/>
+                           value={sentenceLine.justification.lines.text?sentenceLine.justification.lines.text:""}/>
             </Grid>)
         ]
     } else {


### PR DESCRIPTION
This PR implements dynamic line refrences. When a user adds or removes a line or a wholesubproof, the respective references should be updated. There are a few caveats:

1. If a referenced line has been deleted, it will not be altered
2. If a reference could not be parsed, it will not be altered