### PR TITLE
added basic EqualsIntro

### DIFF
--- a/src/fitch/grammar.peggy
+++ b/src/fitch/grammar.peggy
@@ -38,7 +38,7 @@ Atom
 
 Term
 	= fun:functionConVarSym par:("(" (Term|1..,","|)  ")")?  {if(!par){return {type:"const", const:fun};}else{return {type: "fun", fun:fun, terms:par[1]};}}
-
+  
 predicateSym
   = $([A-uw-z][A-uw-z]*)
 
@@ -50,10 +50,12 @@ binop
   / '|' {return "\u2228"}
   / '>' {return "\u2192"}
   / '<>' {return "\u2194"}
+  / '=' {return "\u003D"}
   / '\u2227'
   / '\u2228'
   / '\u2192'
   / '\u2194'
+  / '\u003D'
 
 neg
  = '~' {return "\u00AC";} / '\u00AC'

--- a/src/fitch/rules.js
+++ b/src/fitch/rules.js
@@ -83,13 +83,19 @@ function printLines(lines){
 export class Rule {
     static derived = [];
     static label = "";
+    static isIdentityIntro = false;
 
     static check(proof, lines, target, target_line, premiseEnd) {
 
         try{
-            if(!lines){
+            if(!lines && !this.isIdentityIntro){
                 throw new RuleError("No referenced lines")
             }
+
+            if(!lines && this.isIdentityIntro){
+                lines = [] // Dummy value so check goes through
+            }
+
             this._check(lines.map((x) => resolveReference(proof, x, target_line, premiseEnd)), target)
         } catch (error) {
             if(error instanceof RuleError){
@@ -150,6 +156,29 @@ export class Assumption extends Rule {
     }
 
     static _check(references, target) {
+    }
+}
+
+// Id: Identity of variable
+export class Identity extends Rule {
+    static label = "\u003D-Intro";
+    static isIdentityIntro = true;
+    static {
+        register(this);
+    }
+
+    static _check(references, target){
+        if(references.length > 0){
+            throw new RuleError("Identity intro cannot have any lines.")
+        }
+
+        if(!(target instanceof BinarySentence) || (target.op !== BinaryOp.ID)){
+            throw new RuleError("Formula being derived must be an identity.")
+        }
+
+        if(!(target.left.equals(target.right))){
+            throw new RuleError("Left hand side does not equal right hand side.")
+        }
     }
 }
 

--- a/src/fitch/structure.js
+++ b/src/fitch/structure.js
@@ -310,6 +310,7 @@ export const BinaryOp = {
     OR: "\u2228",
     IMPL: "\u2192",
     BIMPL: "\u2194",
+    ID: "\u003D"
 };
 
 function readBinaryOp(input) {
@@ -322,6 +323,8 @@ function readBinaryOp(input) {
             return BinaryOp.IMPL
         case("\u2194"):
             return BinaryOp.BIMPL
+        case("\u003D"):
+            return BinaryOp.ID
         default:
             throw Error("Unknown input: " + input)
     }


### PR DESCRIPTION
This PR implements a basic Equals/Idendity-Intro rule so #27 and #24 can be closed.

One thing to note is that the base `Rule` class automatically assumes that all rules have references and since I am not very experienced with JavaScript, I made a basic workaround (a simple boolean check) for now to avoid breaking the behaviour of other rules.