### PR TITLE
Fix predicate parsing

### DIFF
--- a/src/fitch/grammar.peggy
+++ b/src/fitch/grammar.peggy
@@ -40,7 +40,7 @@ Term
 	= fun:functionConVarSym par:("(" (Term|1..,","|)  ")")?  {if(!par){return {type:"const", const:fun};}else{return {type: "fun", fun:fun, terms:par[1]};}}
 
 predicateSym
-  = $([A-uw-z][A-uw-z]*)
+  = $([A-Z][A-z]*)
 
 functionConVarSym
   = $([a-z]+)

--- a/src/fitch/structure.js
+++ b/src/fitch/structure.js
@@ -15,7 +15,7 @@ function process(input) {
         case("fun"):
             return new FunctionTerm(input.fun, input.terms.map((x) => process(x)))
         case("pred"):
-            return new FunctionTerm(input.pred, input.terms.map((x) => process(x)))
+            return new Atom(input.pred, input.terms.map((x) => process(x)))
         case("falsum"):
             return new Falsum()
         case("atom"):
@@ -198,7 +198,7 @@ export class Atom extends Sentence {
             return false
 
         if (other.predicate !== this.predicate)
-            return
+            return false
 
         return this.terms.every((x,i) => x.equals(other.terms[i]))
     }
@@ -220,8 +220,18 @@ export class PropAtoms extends Sentence {
     }
 }
 
-export class Term extends Atom {
+export class Term {
+    get text() {
+        throw "Not implemented"
+    }
 
+    equals(other){
+        throw "Not implemented"
+    }
+
+    substitute(vari, cons) {
+        throw "Not implemented"
+    }
 }
 
 export class FunctionTerm extends Term {

--- a/test/parser/reader.test.js
+++ b/test/parser/reader.test.js
@@ -1,0 +1,30 @@
+import {describe, expect, it} from "vitest";
+import {parse, Atom, PropAtoms, Constant, BinarySentence, BinaryOp} from "../../src/fitch/structure.js";
+
+
+const
+    A = new PropAtoms("A"),
+    B = new PropAtoms("B"),
+    C = new PropAtoms("C"),
+    and = (x,y) => new BinarySentence(x, BinaryOp.AND, y),
+    or = (x,y) => new BinarySentence(x, BinaryOp.OR, y),
+    lif = (x,y) => new BinarySentence(x, BinaryOp.IMPL, y),
+    liff = (x,y) => new BinarySentence(x, BinaryOp.BIMPL, y)
+
+const cases = [
+    ["A", A],
+    ["P(a)", new Atom("P", [new Constant("a")])],
+    ["A&B", and(A,B)],
+    ["A|B", or(A,B)],
+    ["A>B", lif(A,B)],
+    ["A<>B", liff(A,B)],
+    ["A&(B&C)", and(A,and(B,C))],
+]
+
+describe(`Reader test`, () => {
+    for(const [string, structure] of cases) {
+        it(`Roundtrip ${string} should be ${structure.text}`, () => {
+            expect(parse(string).equals(structure)).equals(true);
+        });
+    }
+})

--- a/test/parser/reader_neg.test.js
+++ b/test/parser/reader_neg.test.js
@@ -1,0 +1,27 @@
+import {describe, expect, it} from "vitest";
+import {parse, FunctionTerm, PropAtoms, Constant} from "../../src/fitch/structure.js";
+const wrongParsings = [
+    ["P(a)", new FunctionTerm("P", [new Constant("a")])],
+]
+
+describe(`Negative reader test`, () => {
+    for(const [string, structure] of wrongParsings) {
+        it(`Roundtrip ${string} should not be ${structure.text}`, () => {
+            expect(parse(string).equals(structure)).equals(false);
+        });
+    }
+})
+
+const faultyIput = [
+    "f(a)",
+    "a",
+    "x"
+]
+
+describe(`Invalid reader test`, () => {
+    for(const string of faultyIput) {
+        it(`Roundtrip ${string} should not parse`, () => {
+            expect(() => parse(string)).toThrowError(SyntaxError);
+        });
+    }
+})

--- a/test/parser/roundtrip.test.js
+++ b/test/parser/roundtrip.test.js
@@ -13,7 +13,7 @@ describe("simple conjunction introduction", () => {
         "~(A|~A)",
     ].map((x) => x.split("").map((y) => charmap[y]??y).join(""))
     for(const text of texts) {
-        it(`Roundtrip &{text}`, () => {
+        it(`Roundtrip ${text}`, () => {
             expect(parse(text).text).equals(text);
         });
     }


### PR DESCRIPTION
Fixes two bugs:
1. Predicates were allowed to be lower-case
2. Atoms were wrongfully parsed as FunctionTerms