### PR TITLE
Fix availability check, for nested subproofs

### DIFF
--- a/src/fitch/rules.js
+++ b/src/fitch/rules.js
@@ -32,12 +32,14 @@ function isAvailable(lines, referencedLineIndex, targetLineIndex, premiseEnd){
             if(availablePerLayer.length-1 < li.level){ // A new, lower subproof
                 availablePerLayer.push([i])
             } else {
-                const finishedSubproof = availablePerLayer.pop()
-                availablePerLayer[availablePerLayer.length-1].push([finishedSubproof[0],finishedSubproof[finishedSubproof.length-1]]) // This subproof is now available
+                while(li.level <= availablePerLayer.length-1){
+                    const finishedSubproof = availablePerLayer.pop()
+                    availablePerLayer[availablePerLayer.length-1].push([finishedSubproof[0],finishedSubproof[finishedSubproof.length-1]])
+                } // This subproof is now available
                 availablePerLayer.push([i])
             }
         } else {
-            if(li.level < availablePerLayer.length-1){
+            while(li.level < availablePerLayer.length-1){
                 const finishedSubproof = availablePerLayer.pop()
                 availablePerLayer[availablePerLayer.length-1].push([finishedSubproof[0],finishedSubproof[finishedSubproof.length-1]])
             }

--- a/test/proof/availability.test.js
+++ b/test/proof/availability.test.js
@@ -1,0 +1,27 @@
+import {Assumption, ConjunctionElim, ConjunctionIntro, FalsumIntro} from "../../src/fitch/rules.js";
+import {validProofTest} from "./base.js";
+
+const test_proof = [
+    [
+        ["", Assumption, []]
+    ],
+    [
+        [
+            ["A", Assumption, []],
+            [
+                ["~A", Assumption, []],
+                ["#", FalsumIntro, [1,2]],
+            ]
+        ],
+        [
+            ["~A", Assumption, []],
+            [
+                ["A", Assumption, []],
+                ["#", FalsumIntro, [4,5]],
+            ]
+        ]
+
+    ]
+]
+
+validProofTest(test_proof)

--- a/test/proof/base.js
+++ b/test/proof/base.js
@@ -1,0 +1,40 @@
+import {describe, expect, it} from "vitest";
+import {RuleError, Assumption} from "../../src/fitch/rules.js";
+import {Justification, SentenceLine} from "../../src/fitch/proofstructure.js";
+
+function constructLine([text, rule, refs], level){
+    console.log([text, rule, refs, rule === Assumption])
+    let jus = new Justification(rule, {processed:refs})
+    return new SentenceLine(text, jus, level, rule === Assumption)
+}
+
+
+function constructProof(proof, level){
+    let lines = []
+    for(const linOrSub of proof){
+        if(linOrSub[0] instanceof Array) {
+            const subproof = constructProof(linOrSub,level + 1)
+            lines = lines.concat(subproof)
+        } else {
+            const line= constructLine(linOrSub, level)
+            lines.push(line)
+        }
+    }
+    return lines
+}
+
+
+export function validProofTest([premises, proofLines]){
+    const premisesEnd = premises.length
+
+    let proof = constructProof(premises.concat(proofLines), 0)
+    describe(`invalid {${proof.slice(0,premisesEnd).join(", ")}} |- ${proof[proof.length-1]}`, () => {
+        for(let i=premisesEnd; i<proof.length; i++){
+            const sentenceLine=proof[i]
+            it(`${sentenceLine.sentence} ${sentenceLine.justification.rule.label} ${sentenceLine.justification.rule.lines}`, () => {
+                expect(()=>sentenceLine.check(proof, i, premisesEnd)).not.toThrowError(RuleError)
+            });
+        }
+    });
+
+}


### PR DESCRIPTION
The original implementation did not consider that several subproofs could end at the same line. While this is not the case for complete proofs, it may happen during proof development.