### PR TITLE
Fix handling of empty strings in references

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "**" ]
 
 jobs:
   build:

--- a/src/components/ProofBox.jsx
+++ b/src/components/ProofBox.jsx
@@ -120,12 +120,12 @@ export default function ProofBox({
                     alignItems: "flex-start"
                 }}>
                     <Button sx={{fontSize: 10}} onClick={() => {
-                        addLine(new SentenceLine("", new Justification(Rule.derived["Reit"], {}), layer, false), lastLineNumber + 1);
+                        addLine(new SentenceLine("", new Justification(Rule.derived["Reit"], {text:"", processed:[]}), layer, false), lastLineNumber + 1);
                     }}
                     > Add Line
                     </Button>
                     <Button sx={{fontSize: 10}} onClick={() => {
-                        addLine(new SentenceLine("", new Justification(Rule.derived["Assumption"], {}), layer + 1, true), lastLineNumber + 1);
+                        addLine(new SentenceLine("", new Justification(Rule.derived["Assumption"], {text:"", processed:[]}), layer + 1, true), lastLineNumber + 1);
                     }}
                     > Start Subproof </Button>
                 </Box>

--- a/src/components/ProofLineBox.jsx
+++ b/src/components/ProofLineBox.jsx
@@ -16,6 +16,8 @@ import Menu from "@mui/material/Menu";
 import SentenceComponent from "./SentenceComponent.jsx";
 
 function readLinesText(text) {
+    if(text === "")
+        return {text: text, processed: []}
     let vs = text.split(",");
     for (let i = 0; i < vs.length; i++) {
         if (vs[i].includes("-")) {
@@ -30,9 +32,12 @@ function readLinesText(text) {
                 vs[i] = [a-1, b-1]
             }
         }
-        else {
-            vs[i] = Number(vs[i])-1
-        }
+        else
+            if(vs[i] === "")
+                vs[i] = null
+            else
+                vs[i] = Number(vs[i])-1
+
     }
     return {text: text, processed: vs}
 }

--- a/src/fitch/rules.js
+++ b/src/fitch/rules.js
@@ -87,14 +87,15 @@ export class Rule {
     static label = "";
 
     static check(proof, lines, target, target_line, premiseEnd) {
+        const targetSentenceLine = proof[target_line]
         try{
-            if(lines.length === 0 && !(target.justification.rule instanceof IdentityIntro) && !(target.justification.rule instanceof Assumption)){
+            if(lines.length === 0 && !(targetSentenceLine.justification.rule === IdentityIntro) && !(targetSentenceLine.justification.rule === Assumption)){
                 throw new RuleError("No referenced lines")
             }
-            target.justification.rule._check(lines.map((x) => resolveReference(proof, x, target_line, premiseEnd)), target)
+            targetSentenceLine.justification.rule._check(lines.map((x) => resolveReference(proof, x, target_line, premiseEnd)), target)
         } catch (error) {
             if(error instanceof RuleError){
-                error.message =  `[ERROR applying ${target.justification.rule.label} to lines ${lines?printLines(lines):lines}]: ${error.message}`
+                error.message =  `[ERROR applying ${targetSentenceLine.justification.rule.label} to lines ${lines?printLines(lines):lines}]: ${error.message}`
             }
             throw error
         }

--- a/src/fitch/rules.js
+++ b/src/fitch/rules.js
@@ -85,23 +85,16 @@ function printLines(lines){
 export class Rule {
     static derived = [];
     static label = "";
-    static isIdentityIntro = false;
 
     static check(proof, lines, target, target_line, premiseEnd) {
-
         try{
-            if(!lines && !this.isIdentityIntro){
+            if(lines.length === 0 && !(target.justification.rule instanceof IdentityIntro) && !(target.justification.rule instanceof Assumption)){
                 throw new RuleError("No referenced lines")
             }
-
-            if(!lines && this.isIdentityIntro){
-                lines = [] // Dummy value so check goes through
-            }
-
-            this._check(lines.map((x) => resolveReference(proof, x, target_line, premiseEnd)), target)
+            target.justification.rule._check(lines.map((x) => resolveReference(proof, x, target_line, premiseEnd)), target)
         } catch (error) {
             if(error instanceof RuleError){
-                error.message =  `[ERROR applying ${this.label} to lines ${lines?printLines(lines):lines}]: ${error.message}`
+                error.message =  `[ERROR applying ${target.justification.rule.label} to lines ${lines?printLines(lines):lines}]: ${error.message}`
             }
             throw error
         }
@@ -162,9 +155,8 @@ export class Assumption extends Rule {
 }
 
 // Id: Identity of variable
-export class Identity extends Rule {
+export class IdentityIntro extends Rule {
     static label = "\u003D-Intro";
-    static isIdentityIntro = true;
     static {
         register(this);
     }

--- a/test/rules/identIntro.test.js
+++ b/test/rules/identIntro.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import {invalidRuleTestWithParser, ruleTestWithParser} from "./base.js"
+import {IdentityIntro,} from "../../src/fitch/rules.js";
+
+describe("negation introduction with parsing", () => {
+    const testcases = [
+        [[], "a=a"],
+    ]
+    ruleTestWithParser(IdentityIntro, testcases)
+});
+
+const invalidTestcases = [
+    [[], "a=b"],
+]
+
+invalidRuleTestWithParser(IdentityIntro, invalidTestcases)


### PR DESCRIPTION
* Set text default to ""
* Set processed default to []
* Properly check for rule
* Use target rule in rule check

Looking at the check() function, we can probably pull it out of the Rule method inf future releases, as it does not use any of the class' variables.